### PR TITLE
use conventional async tests without `done` callback

### DIFF
--- a/test/effect.test.js
+++ b/test/effect.test.js
@@ -2,7 +2,7 @@
 import { h, useLayout } from '../src/index'
 import { testUpdates } from './test-util'
 
-test('useLayout(f, [x]) should run on changes to x', async done => {
+test('useLayout(f, [x]) should run on changes to x', async () => {
   let effects = []
 
   const effect = value => {
@@ -43,13 +43,12 @@ test('useLayout(f, [x]) should run on changes to x', async done => {
       content: <div>removed</div>,
       test: () => {
         expect(effects).toEqual(['cleanUp 1'])
-        done()
       }
     }
   ])
 })
 
-test('useEffect(f, []) should run only once', async done => {
+test('useEffect(f, []) should run only once', async () => {
   let effects = []
 
   const effect = () => {
@@ -84,13 +83,12 @@ test('useEffect(f, []) should run only once', async done => {
       content: <div>removed</div>,
       test: () => {
         expect(effects).toEqual(['cleanUp'])
-        done()
       }
     }
   ])
 })
 
-test('useLayout(f) should run every time', async done => {
+test('useLayout(f) should run every time', async () => {
   let effects = []
 
   const effect = value => {
@@ -132,7 +130,6 @@ test('useLayout(f) should run every time', async done => {
       content: <div>removed</div>,
       test: () => {
         expect(effects).toEqual(['cleanUp 2'])
-        done()
       }
     }
   ])

--- a/test/reconcilation.test.jsx
+++ b/test/reconcilation.test.jsx
@@ -2,7 +2,7 @@
 import { h, useState } from '../src/index'
 import { testUpdates } from './test-util'
 
-test('reorder and reuse elements during key-based reconciliation of child-nodes', async done => {
+test('reorder and reuse elements during key-based reconciliation of child-nodes', async () => {
   const states = [
     [1, 2, 3],
     [3, 1, 2], // shift right
@@ -52,7 +52,6 @@ test('reorder and reuse elements during key-based reconciliation of child-nodes'
         }
 
         lastChildren = children
-        done()
       }
     }))
   )

--- a/test/ref.test.js
+++ b/test/ref.test.js
@@ -29,7 +29,7 @@ test('persist reference to any value', async () => {
   ])
 })
 
-test('refs with callback and clenups', async done => {
+test('refs with callback and clenups', async () => {
   let refs = []
   const Component = () => {
     const p = dom => {
@@ -65,7 +65,6 @@ test('refs with callback and clenups', async done => {
       content: <div>removed</div>,
       test: () => {
         expect(refs).toEqual(['cleanup', 'cleanup2'])
-        done()
       }
     }
   ])

--- a/test/update.test.jsx
+++ b/test/update.test.jsx
@@ -2,7 +2,7 @@
 import { h, useState, useRef } from '../src/index'
 import { testUpdates } from './test-util'
 
-test('async state update', async done => {
+test('async state update', async () => {
   let updates = 0
 
   const Component = () => {
@@ -33,13 +33,12 @@ test('async state update', async done => {
       test: ([button]) => {
         expect(+button.textContent).toBe(3) // all 3 state updates applied
         expect(updates).toBe(2)
-        done()
       }
     }
   ])
 })
 
-test('persist reference to any value', async done => {
+test('persist reference to any value', async () => {
   const Component = () => {
     const ref = useRef('')
 
@@ -61,7 +60,6 @@ test('persist reference to any value', async done => {
       content,
       test: ([p]) => {
         expect(p.textContent).toBe('x')
-        done()
       }
     }
   ])


### PR DESCRIPTION
This PR removes all the `done` callbacks.

Conventional tests in Jest use one of two formats, either with `async` and `Promise`:

    async () => { /* ... */ return new Promise(...) }

Or with a manual callback:

    (done) => { /* ... */ done(); }

But never with both.

The `done` callback format mostly exists to support code written before Promises were around.

As you can see, the `done` callbacks are not necessary, because `testUpdates` returns a Promise.

But this change reveals [a bug](https://github.com/yisar/fre/commit/805dd32cd0efc7a4d97785a7db85cbaa8815477e#diff-368306c2b3b81065366d8e255a47326fL55) in `reconciliation.test.jsx`, where you called `done` inside a loop - which means `done` will be called during the *first* iteration, and every iteration after, but those calls simply get ignored.

Jest is pretty braindead here - it *will* let you call `done` at any time, as many times as you want, or not at all... but it simply *ignores* any assertions made after the first call to `done` - exiting your test and then making more assertions of course should be an error, but Jest doesn't even report this. 😣

What this means is, you don't really know if all of your tests have been run or not - in this case, only the first iteration of that loop was actually being run, the rest would quietly fail.

So this test is now failing like it should, though I haven't gotten as far yet as to figure out why...
