### PR TITLE
Fix publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "1.11.5",
   "description": "",
   "main": "dist/fre.js",
-  "unpkg": "dist/fre-umd.js",
-  "module": "dist/fre-esm.js",
+  "unpkg": "dist/fre.js",
+  "module": "dist/fre.esm.js",
   "files": [
     "src/**/*",
     "dist/*.js",
@@ -12,7 +12,7 @@
   ],
   "scripts": {
     "test": "jest --coverage",
-    "test-key":"jest ./test/reconcilation.test.js",
+    "test-key": "jest ./test/reconcilation.test.js",
     "build": "rollup -c && gzip-size dist/fre.js",
     "format": "prettier --write \"{src,test,demo}/**/*.js\"",
     "prepublish": "node prepublish.js"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test-key": "jest ./test/reconcilation.test.js",
     "build": "rollup -c && gzip-size dist/fre.js",
     "format": "prettier --write \"{src,test,demo}/**/*.js\"",
-    "prepublish": "node prepublish.js"
+    "prepublishOnly": "node prepublish.js"
   },
   "keywords": [],
   "author": "132yse",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test": "jest --coverage",
     "test-key":"jest ./test/reconcilation.test.js",
     "build": "rollup -c && gzip-size dist/fre.js",
-    "format": "prettier --write \"{src,test,demo}/**/*.js\""
+    "format": "prettier --write \"{src,test,demo}/**/*.js\"",
+    "prepublish": "node prepublish.js"
   },
   "keywords": [],
   "author": "132yse",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,13 @@
   "main": "dist/fre.js",
   "unpkg": "dist/fre-umd.js",
   "module": "dist/fre-esm.js",
+  "files": [
+    "src/**/*",
+    "dist/fre.js",
+    "dist/fre-esm.js",
+    "dist/fre-umd.js",
+    "dist/*.map"
+  ],
   "scripts": {
     "test": "jest --coverage",
     "test-key":"jest ./test/reconcilation.test.js",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,7 @@
   "module": "dist/fre-esm.js",
   "files": [
     "src/**/*",
-    "dist/fre.js",
-    "dist/fre-esm.js",
-    "dist/fre-umd.js",
+    "dist/*.js",
     "dist/*.map"
   ],
   "scripts": {

--- a/prepublish.js
+++ b/prepublish.js
@@ -1,0 +1,14 @@
+const fs = require('fs')
+
+const paths = [
+  "dist/fre.js",
+  "dist/fre-esm.js",
+  "dist/fre-umd.js",
+]
+
+for (path of paths) {
+  if (! fs.existsSync(path)) {
+    process.stderr.write(`ERROR: missing required file "${path}"\n\n`)
+    process.exit(1)
+  }
+}

--- a/prepublish.js
+++ b/prepublish.js
@@ -2,11 +2,10 @@ const fs = require('fs')
 
 const paths = [
   "dist/fre.js",
-  "dist/fre-esm.js",
-  "dist/fre-umd.js",
+  "dist/fre.esm.js",
 ]
 
-for (path of paths) {
+for (const path of paths) {
   if (! fs.existsSync(path)) {
     process.stderr.write(`ERROR: missing required file "${path}"\n\n`)
     process.exit(1)

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,10 +3,8 @@ import { terser } from "rollup-plugin-terser"
 export default {
   input: "src/index.js",
   output: [
-    { file: "dist/fre.js", format: "cjs", esModule: false, sourcemap: true },
-    { file: "dist/fre-cjs.js", format: "cjs", esModule: false, sourcemap: true },
-    { file: "dist/fre-umd.js", format: "umd", esModule: false, name: "fre", sourcemap: true },
-    { file: "dist/fre-esm.js", format: "esm", esModule: false, sourcemap: true },
+    { file: "dist/fre.js", format: "umd", esModule: false, name: "fre", sourcemap: true },
+    { file: "dist/fre.esm.js", format: "esm", esModule: false, sourcemap: true },
   ],
   plugins: [
     terser({


### PR DESCRIPTION
I noticed some inconsistency in which files are being published with each release - it seems to depend on what you happened to have in your `dist` folder at the time. For example, the [1.11.6 release](https://unpkg.com/browse/fre@1.11.6/dist/) didn't contain any of the module builds.

So I've added a `prepublish` script that checks for the expected `dist` files and aborts the publish if anything is missing.

I also noticed we're currently publishing everything, including `demo` and `test` folders - so I've added a `files` listing to `package.json` specifying which files to publish. (According to [this answer](https://stackoverflow.com/a/43613888/283851), the `src` folder *should* be published as a best practice, although it isn't strictly needed.)

Finally, I noticed [you added](https://github.com/yisar/fre/commit/eaf6cb3d8fd88c1f76f7522812edc3e49bdcecd1#diff-ff6e5f22a9c7e66987b19c0199636480R7) an extra `dist/fre-cjs.js` file, which doesn't seem to be referenced in `package.json` or anywhere else - this file is identical to `fre.js`, so I'm not sure what this is for. The commit log says "update readme, add contributors and sponsors", so maybe you added this by accident?

I've omitted the `fre-cjs.js` file from the `prepublish.js` script, but I wanted to check with you first if there's a reason for this?

Why do we have 3 or 4 versions in `dist` in the first place? The UMD version will work as either CommonJS, AMD or global - I'm not sure why we would need more than two vesions: the UMD version and the ES6 module version for modern browsers and bundlers?

Don't merge this before we figure out these details 😉