### PR TITLE
optimize reconciler.commit method

### DIFF
--- a/src/reconciler.js
+++ b/src/reconciler.js
@@ -202,21 +202,22 @@ function commit(fiber) {
   let parent = fiber.parentNode
   let dom = fiber.node
   let ref = fiber.ref
+  const fiberHooks = fiber.hooks;
   if (op === NOWOEK) {
   } else if (op === DELETE) {
-    fiber.hooks && fiber.hooks.list.forEach(e => e[2] && e[2]())
+    fiberHooks && fiberHooks.list.forEach(e => e[2] && e[2]())
     cleanupRef(fiber.kids)
     while (fiber.tag === HOOK) fiber = fiber.child
     parent.removeChild(fiber.node)
   } else if (fiber.tag === HOOK) {
-    if (fiber.hooks) {
-      fiber.hooks.layout.forEach(cleanup)
-      fiber.hooks.layout.forEach(effect)
-      fiber.hooks.layout = []
+    if (fiberHooks) {
+      fiberHooks.layout.forEach(cleanup)
+      fiberHooks.layout.forEach(effect)
+      fiberHooks.layout = []
       defer(() => {
-        fiber.hooks.effect.forEach(cleanup)
-        fiber.hooks.effect.forEach(effect)
-        fiber.hooks.effect = []
+        fiberHooks.effect.forEach(cleanup)
+        fiberHooks.effect.forEach(effect)
+        fiberHooks.effect = []
       })
     }
   } else if (op === UPDATE) {


### PR DESCRIPTION
optimize: in reconciler/commit method, we should declare fiberHooks just one time for performance reason, you know, every dot operation is a hash get process for js engine