### PR TITLE
Include typescript typings in the npm tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "files": [
     "src/**/*",
     "dist/*.js",
-    "dist/*.map"
+    "dist/*.map",
+    "index.d.ts"
   ],
   "scripts": {
     "test": "jest --coverage",


### PR DESCRIPTION
With the current `1.13.5` the typescript declarations are not included properly.