### PR TITLE
D

### DIFF
--- a/demo/src/use-state.tsx
+++ b/demo/src/use-state.tsx
@@ -2,12 +2,16 @@ import { h, render, useEffect, useState } from '../../src/index'
 
 function App() {
   const [count, setCount] = useState(0)
-  useEffect(()=>{
-    console.log(123)
+  const [two, setTwo] = useState(0)
+  useEffect(() => {
+    setTimeout(() => {
+      setTwo(two + 1)
+    }, 1000)
   })
+  // console.log(count,two)
   return (
     <div>
-      <button onClick={() => setCount(count + 1)}>{count}</button>
+      <button onClick={() => setCount(count + 1, 6)}>{two}</button>
     </div>
   )
 }

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -8,7 +8,7 @@ export const options: Option = {}
 let preCommit: IFiber | undefined
 let currentFiber: IFiber
 let WIP: IFiber | undefined
-let syncQueue: IFiber[] = []
+let microTask: IFiber[] = []
 let commitQueue: IFiber[] = []
 const lanes: Array<number> = [2, 3]
 
@@ -24,13 +24,13 @@ export const render = (vnode: FreElement, node: Element | Document | DocumentFra
 export const scheduleWork = (fiber: IFiber) => {
   if (!fiber.lane) {
     fiber.lane = true
-    syncQueue.push(fiber)
+    microTask.push(fiber)
   }
   scheduleCallback(reconcileWork as ITaskCallback)
 }
 
 const reconcileWork = (timeout: boolean): boolean | null | ITaskCallback => {
-  if (!WIP) WIP = syncQueue.shift()
+  if (!WIP) WIP = microTask.shift()
   while (WIP && (!shouldYeild() || timeout)) {
     WIP = reconcile(WIP)
   }

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -8,7 +8,7 @@ export const options: Option = {}
 let preCommit: IFiber | undefined
 let currentFiber: IFiber
 let WIP: IFiber | undefined
-let updateQueue: IFiber[] = []
+let syncQueue: IFiber[] = []
 let commitQueue: IFiber[] = []
 const lanes: Array<number> = [2, 3]
 
@@ -24,13 +24,13 @@ export const render = (vnode: FreElement, node: Element | Document | DocumentFra
 export const scheduleWork = (fiber: IFiber) => {
   if (!fiber.lane) {
     fiber.lane = true
-    updateQueue.push(fiber)
+    syncQueue.push(fiber)
   }
   scheduleCallback(reconcileWork as ITaskCallback)
 }
 
 const reconcileWork = (timeout: boolean): boolean | null | ITaskCallback => {
-  if (!WIP) WIP = updateQueue.shift()
+  if (!WIP) WIP = syncQueue.shift()
   while (WIP && (!shouldYeild() || timeout)) {
     WIP = reconcile(WIP)
   }

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1,7 +1,7 @@
 import { ITask, ITaskCallback, IVoidCb } from './type'
 import { isFn } from './reconciler'
 
-let asyncQueue: ITask[] = []
+let macroTask: ITask[] = []
 let currentCallback: ITaskCallback | undefined
 let frameDeadline: number = 0
 const frameLength: number = 5
@@ -16,14 +16,14 @@ export const scheduleCallback = (callback: ITaskCallback): void => {
     dueTime,
   }
 
-  asyncQueue.push(newTask)
+  macroTask.push(newTask)
   currentCallback = flush as ITaskCallback
   planWork()
 }
 
 const flush = (iniTime: number): boolean => {
   let currentTime = iniTime
-  let currentTask = peek(asyncQueue)
+  let currentTask = peek(macroTask)
 
   while (currentTask) {
     const timeout = currentTask.dueTime <= currentTime
@@ -33,9 +33,9 @@ const flush = (iniTime: number): boolean => {
     currentTask.callback = null
 
     let next = isFn(callback) && callback(timeout)
-    next ? (currentTask.callback = next) : asyncQueue.shift()
+    next ? (currentTask.callback = next) : macroTask.shift()
 
-    currentTask = peek(asyncQueue)
+    currentTask = peek(macroTask)
     currentTime = getTime()
   }
 

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1,7 +1,7 @@
 import { ITask, ITaskCallback, IVoidCb } from './type'
 import { isFn } from './reconciler'
 
-let taskQueue: ITask[] = []
+let asyncQueue: ITask[] = []
 let currentCallback: ITaskCallback | undefined
 let frameDeadline: number = 0
 const frameLength: number = 5
@@ -16,14 +16,14 @@ export const scheduleCallback = (callback: ITaskCallback): void => {
     dueTime,
   }
 
-  taskQueue.push(newTask)
+  asyncQueue.push(newTask)
   currentCallback = flush as ITaskCallback
   planWork()
 }
 
 const flush = (iniTime: number): boolean => {
   let currentTime = iniTime
-  let currentTask = peek(taskQueue)
+  let currentTask = peek(asyncQueue)
 
   while (currentTask) {
     const timeout = currentTask.dueTime <= currentTime
@@ -33,9 +33,9 @@ const flush = (iniTime: number): boolean => {
     currentTask.callback = null
 
     let next = isFn(callback) && callback(timeout)
-    next ? (currentTask.callback = next) : taskQueue.shift()
+    next ? (currentTask.callback = next) : asyncQueue.shift()
 
-    currentTask = peek(taskQueue)
+    currentTask = peek(asyncQueue)
     currentTime = getTime()
   }
 


### PR DESCRIPTION
允许进行二次调度（异步）

同时对 fre 中的两个队列进行了重命名，使用了 macrotask 和 microtask 的源语

但和 eventloop 的宏任务微任务机制相似，但本质又不同

fre 中的宏任务队列，装的是 reconcile 函数，意思是这个队列里的 reconcile 是异步的，它是借助 setTimeout 实现的

fre 中的微任务队列，装的是 fiber 组件，这些组件是在异步函数中，同步一个完了下一个地必须执行完

以上，希望改名后会更容易理解

