### PR TITLE
Naive lane

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -10,7 +10,7 @@
 
 <body>
   <div id="root"></div>
-  <script src="./src/use-state.tsx"></script>
+  <script src="./src/throw.tsx"></script>
 </body>
 
 </html>

--- a/demo/src/throw.tsx
+++ b/demo/src/throw.tsx
@@ -8,10 +8,10 @@ const App = () => {
       return () => clearInterval(id)
     }, [])
   const update = () => {
-    setResource(wrapPromise(new Promise((r) => setTimeout(r, 3000)).then(() => 'FETCHED RESULT')))
+    setResource(wrapPromise(new Promise((r) => setTimeout(r, 3000)).then(() => 'FETCHED RESULT')),6)
   }
 
-  // console.log(resource,count)
+  console.log(resource,count)
   return (
     <div>
       <button onClick={update}>CLICK ME</button>

--- a/demo/src/use-state.tsx
+++ b/demo/src/use-state.tsx
@@ -8,7 +8,7 @@ function App() {
       setTwo(two + 1)
     }, 1000)
   })
-  // console.log(count,two)
+  console.log(count,two)
   return (
     <div>
       <button onClick={() => setCount(count + 1, 6)}>{two}</button>

--- a/demo/src/use-state.tsx
+++ b/demo/src/use-state.tsx
@@ -2,12 +2,16 @@ import { h, render, useEffect, useState } from '../../src/index'
 
 function App() {
   const [count, setCount] = useState(0)
-  useEffect(()=>{
-    console.log(123)
+  const [two, setTwo] = useState(0)
+  useEffect(() => {
+    setTimeout(() => {
+      setTwo(two + 1)
+    }, 1000)
   })
+  // console.log(count,two)
   return (
     <div>
-      <button onClick={() => setCount(count + 1)}>{count}</button>
+      <button onClick={() => setCount(count + 1, 6)}>{two}</button>
     </div>
   )
 }

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -14,11 +14,16 @@ export const useReducer = <S, A>(reducer?: Reducer<S, A>, initState?: S): [S, Di
   const [hook, current]: [any, IFiber] = getHook<S>(cursor++)
   hook[2] = divide(hook[2])
   if (hook[2] > 1) {
-    current.lane = 0
+    // current.lane = 0
+    hook[3] = false
     scheduleWork(current)
-    hook[0] = initState
   } else {
-    hook[0] = isFn(hook[1]) ? hook[1](hook[0]) : hook[1] || initState
+    if (hook[3]) {
+      hook[0] = initState
+    } else {
+      hook[0] = isFn(hook[1]) ? hook[1](hook[0]) : hook[1] || initState
+    }
+    if (typeof hook[3] === 'boolean') hook[3] = !hook[3]
   }
   return [
     hook[0] as S,

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -8,7 +8,7 @@ export const options: Option = {}
 let preCommit: IFiber | undefined
 let currentFiber: IFiber
 let WIP: IFiber | undefined
-let syncQueue: IFiber[] = []
+let microTask: IFiber[] = []
 let commitQueue: IFiber[] = []
 const lanes: Array<number> = [2, 3]
 
@@ -24,13 +24,13 @@ export const render = (vnode: FreElement, node: Element | Document | DocumentFra
 export const scheduleWork = (fiber: IFiber) => {
   if (!fiber.lane) {
     fiber.lane = true
-    syncQueue.push(fiber)
+    microTask.push(fiber)
   }
   scheduleCallback(reconcileWork as ITaskCallback)
 }
 
 const reconcileWork = (timeout: boolean): boolean | null | ITaskCallback => {
-  if (!WIP) WIP = syncQueue.shift()
+  if (!WIP) WIP = microTask.shift()
   while (WIP && (!shouldYeild() || timeout)) {
     WIP = reconcile(WIP)
   }

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -8,7 +8,7 @@ export const options: Option = {}
 let preCommit: IFiber | undefined
 let currentFiber: IFiber
 let WIP: IFiber | undefined
-let updateQueue: IFiber[] = []
+let syncQueue: IFiber[] = []
 let commitQueue: IFiber[] = []
 const lanes: Array<number> = [2, 3]
 
@@ -24,13 +24,13 @@ export const render = (vnode: FreElement, node: Element | Document | DocumentFra
 export const scheduleWork = (fiber: IFiber) => {
   if (!fiber.lane) {
     fiber.lane = true
-    updateQueue.push(fiber)
+    syncQueue.push(fiber)
   }
   scheduleCallback(reconcileWork as ITaskCallback)
 }
 
 const reconcileWork = (timeout: boolean): boolean | null | ITaskCallback => {
-  if (!WIP) WIP = updateQueue.shift()
+  if (!WIP) WIP = syncQueue.shift()
   while (WIP && (!shouldYeild() || timeout)) {
     WIP = reconcile(WIP)
   }

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -10,7 +10,6 @@ let currentFiber: IFiber
 let WIP: IFiber | undefined
 let microTask: IFiber[] = []
 let commitQueue: IFiber[] = []
-const lanes: Array<number> = [2, 3]
 
 export const render = (vnode: FreElement, node: Element | Document | DocumentFragment | Comment, done?: () => void): void => {
   let rootFiber = {
@@ -47,7 +46,9 @@ const reconcile = (WIP: IFiber): IFiber | undefined => {
     isFn(WIP.type) ? updateHook(WIP) : updateHost(WIP)
   } catch (e) {
     if (!!e && typeof e.then === 'function') {
-      console.log('111')
+      e.then(res=>{
+        WIP.hooks.list.forEach((s:any)=>s[3]&&(s[3] = undefined))
+      })
       return
     }
   } finally {

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -46,10 +46,7 @@ const reconcile = (WIP: IFiber): IFiber | undefined => {
     isFn(WIP.type) ? updateHook(WIP) : updateHost(WIP)
   } catch (e) {
     if (!!e && typeof e.then === 'function') {
-      e.then(res=>{
-        WIP.hooks.list.forEach((s:any)=>s[3]&&(s[3] = undefined))
-      })
-      return
+      e.then(WIP.hooks.list.forEach((s: any) => s[3] && (s[3] = undefined)))
     }
   } finally {
     WIP.lane = WIP.lane ? false : 0

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1,7 +1,7 @@
 import { ITask, ITaskCallback, IVoidCb } from './type'
 import { isFn } from './reconciler'
 
-let asyncQueue: ITask[] = []
+let macroTask: ITask[] = []
 let currentCallback: ITaskCallback | undefined
 let frameDeadline: number = 0
 const frameLength: number = 5
@@ -16,14 +16,14 @@ export const scheduleCallback = (callback: ITaskCallback): void => {
     dueTime,
   }
 
-  asyncQueue.push(newTask)
+  macroTask.push(newTask)
   currentCallback = flush as ITaskCallback
   planWork()
 }
 
 const flush = (iniTime: number): boolean => {
   let currentTime = iniTime
-  let currentTask = peek(asyncQueue)
+  let currentTask = peek(macroTask)
 
   while (currentTask) {
     const timeout = currentTask.dueTime <= currentTime
@@ -33,9 +33,9 @@ const flush = (iniTime: number): boolean => {
     currentTask.callback = null
 
     let next = isFn(callback) && callback(timeout)
-    next ? (currentTask.callback = next) : asyncQueue.shift()
+    next ? (currentTask.callback = next) : macroTask.shift()
 
-    currentTask = peek(asyncQueue)
+    currentTask = peek(macroTask)
     currentTime = getTime()
   }
 

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1,7 +1,7 @@
 import { ITask, ITaskCallback, IVoidCb } from './type'
 import { isFn } from './reconciler'
 
-let taskQueue: ITask[] = []
+let asyncQueue: ITask[] = []
 let currentCallback: ITaskCallback | undefined
 let frameDeadline: number = 0
 const frameLength: number = 5
@@ -16,14 +16,14 @@ export const scheduleCallback = (callback: ITaskCallback): void => {
     dueTime,
   }
 
-  taskQueue.push(newTask)
+  asyncQueue.push(newTask)
   currentCallback = flush as ITaskCallback
   planWork()
 }
 
 const flush = (iniTime: number): boolean => {
   let currentTime = iniTime
-  let currentTask = peek(taskQueue)
+  let currentTask = peek(asyncQueue)
 
   while (currentTask) {
     const timeout = currentTask.dueTime <= currentTime
@@ -33,9 +33,9 @@ const flush = (iniTime: number): boolean => {
     currentTask.callback = null
 
     let next = isFn(callback) && callback(timeout)
-    next ? (currentTask.callback = next) : taskQueue.shift()
+    next ? (currentTask.callback = next) : asyncQueue.shift()
 
-    currentTask = peek(taskQueue)
+    currentTask = peek(asyncQueue)
     currentTime = getTime()
   }
 


### PR DESCRIPTION
天真的 lane 实现，已经实现了重复渲染

但是现在仍然会阻塞一次，react 不阻塞的原因在于，这两次重复的渲染是并行的（位于 macrotask 中）

fre 现在是将更新当道 microtask 的，所以仍然会阻塞

这需要重构 fre 的调度模型，周六日搞