### PR TITLE
simplify scheduler

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -10,7 +10,7 @@
 
 <body>
   <div id="root"></div>
-  <script src="./src/resume-exception.tsx"></script>
+  <script src="./src/concurrent.tsx"></script>
 </body>
 
 </html>

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,4 +1,4 @@
-import { scheduleWork, isFn, getCurrentFiber } from './reconciler'
+import { scheduleUpdate, isFn, getCurrentFiber } from './reconciler'
 import { DependencyList, Reducer, IFiber, Dispatch, SetStateAction, EffectCallback, HookTpes, RefObject, IEffect } from './type'
 let cursor = 0
 
@@ -22,10 +22,10 @@ export const useReducer = <S, A>(reducer?: Reducer<S, A>, initState?: S): [S, Di
   }
   return [
     hook[0] as S,
-    (action: A | Dispatch<A>, resume?: boolean) => {
+    (action: A | Dispatch<A>) => {
       hook[1] = reducer ? reducer(hook[0], action as A) : action
       hook[3] = reducer && (action as any).type[0] === '*'
-      scheduleWork(current)
+      scheduleUpdate(current)
     },
   ]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { h, Fragment } from './h'
-import { render, scheduleWork, getCurrentFiber, options } from './reconciler'
+import { render, options } from './reconciler'
 import { useState, useReducer, useEffect, useMemo, useCallback, useRef, useLayout } from './hooks'
 export * from './type'
 
@@ -9,7 +9,6 @@ export {
   h as jsxs,
   h as jsxDEV,
   render,
-  scheduleWork,
   useState,
   useReducer,
   useEffect,
@@ -19,6 +18,5 @@ export {
   useLayout,
   useLayout as useLayoutEffect,
   Fragment,
-  getCurrentFiber,
   options,
 }


### PR DESCRIPTION
Refactoring the scheduler, here are the main points;

1. Only use one channel and only post message once.

2. Multiple tasks should be pushed into the a queue and then batch processing.