### PR TITLE
New reconcilation algorithm

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -10,7 +10,7 @@
 
 <body>
   <div id="root"></div>
-  <script src="./src/use-state.tsx"></script>
+  <script src="./src/keys.tsx"></script>
 </body>
 
 </html>

--- a/demo/src/keys.tsx
+++ b/demo/src/keys.tsx
@@ -1,9 +1,9 @@
 import { h, render, useEffect, useState } from '../../src/index'
 
 function App() {
-  const [key, setKey] = useState(['a', 'b', 'c'])
+  const [key, setKey] = useState(['a', 'b', 'c', 'd'])
   return [
-    <button onClick={() => setKey(['b', 'a', 'c'])}></button>,
+    <button onClick={() => setKey(['b', 'c', 'a'])}></button>,
     <ul>
       {key.map((i) => (
         <li key={i}>{i}</li>

--- a/demo/src/keys.tsx
+++ b/demo/src/keys.tsx
@@ -1,0 +1,15 @@
+import { h, render, useEffect, useState } from '../../src/index'
+
+function App() {
+  const [key, setKey] = useState(['a', 'b', 'c'])
+  return [
+    <button onClick={() => setKey(['b', 'a', 'c'])}></button>,
+    <ul>
+      {key.map((i) => (
+        <li key={i}>{i}</li>
+      ))}
+    </ul>,
+  ]
+}
+
+render(<App />, document.getElementById('root'))

--- a/demo/src/keys.tsx
+++ b/demo/src/keys.tsx
@@ -1,9 +1,9 @@
 import { h, render, useEffect, useState } from '../../src/index'
 
 function App() {
-  const [key, setKey] = useState(['a', 'b', 'c', 'd'])
+  const [key, setKey] = useState(['a', 'b', 'c'])
   return [
-    <button onClick={() => setKey(['b', 'c', 'a'])}></button>,
+    <button onClick={() => setKey(['b', 'c', 'a', 'd'])}></button>,
     <ul>
       {key.map((i) => (
         <li key={i}>{i}</li>

--- a/demo/src/use-state.tsx
+++ b/demo/src/use-state.tsx
@@ -5,7 +5,7 @@ function App() {
   // const [two, setTwo] = useState(0)
   return (
     <div>
-      <button onClick={() => setCount(count + 1)}>{count}</button>
+      <button onClick={() => setCount(count + 1)}>{count}{count}</button>
     </div>
   )
 }

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -118,8 +118,8 @@ const reconcileChildren = (WIP: any, children: FreNode): void => {
       newFiber.lastProps = oldKids[oldHead].props
       newFiber.node = oldKids[oldHead].node
       newFiber.kids = oldKids[oldHead].kids
-      // console.log(oldKids[oldHead],newKids[newTail],oldKids[oldTail + 1].node)
-      newFiber.insertPoint = oldKids[oldTail + 1].node
+      console.log(oldTail)
+      newFiber.insertPoint = oldKids[oldTail].node.nextSibling
       oldHead++
       newTail--
     } else if (oldKids[oldTail].key === newKids[newHead].key) {

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -68,7 +68,6 @@ const updateHook = <P = Attributes>(WIP: IFiber): void => {
 
 const updateHost = (WIP: IFiber): void => {
   if (!WIP.node) {
-    if (WIP.type === 'svg') WIP.op |= 1 << 4
     WIP.node = createElement(WIP) as HTMLElementEx
   }
   reconcileChildren(WIP, WIP.props.children)
@@ -189,8 +188,8 @@ const commitWork = (fiber: IFiber): void => {
 }
 
 const commit = (fiber: IFiber): void => {
-  const { tag, op, parentNode, node, ref, hooks } = fiber
-  if (op & (1 << 3)) {
+  const { tag, parentNode, node, ref, hooks } = fiber
+  if (tag & (1 << 3)) {
     hooks?.list.forEach(cleanup)
     cleanupRef(fiber.kids)
     while (isFn(fiber.type)) fiber = fiber.child

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -79,17 +79,15 @@ const getParentNode = (WIP: IFiber): HTMLElement | undefined => {
   }
 }
 
+
 const reconcileChildren = (WIP: any, children: FreNode): void => {
   let oldKids = WIP.kids || [],
     newKids = (WIP.kids = hashfy(children) as any),
     oldHead = 0,
     newHead = 0,
     oldTail = oldKids.length - 1,
-    newTail = newKids.length - 1,
-    prev = null,
-    index = 0
+    newTail = newKids.length - 1
 
-  // console.log(oldKids,newKids)
   while (oldHead <= oldTail && newHead <= newTail) {
     let newFiber = null
     if (oldKids[oldHead] == null) {
@@ -118,7 +116,6 @@ const reconcileChildren = (WIP: any, children: FreNode): void => {
       newFiber.lastProps = oldKids[oldHead].props
       newFiber.node = oldKids[oldHead].node
       newFiber.kids = oldKids[oldHead].kids
-      console.log(oldTail)
       newFiber.insertPoint = oldKids[oldTail].node.nextSibling
       oldHead++
       newTail--
@@ -150,14 +147,6 @@ const reconcileChildren = (WIP: any, children: FreNode): void => {
       }
       newHead++
     }
-    newFiber.parent = WIP
-    if (index === 0) {
-      WIP.child = newFiber
-    } else {
-      prev.sibling = newFiber
-    }
-    prev = newFiber
-    index++
   }
   if (oldHead > oldTail) {
     for (let i = newHead; i <= newTail; i++) {
@@ -165,14 +154,6 @@ const reconcileChildren = (WIP: any, children: FreNode): void => {
       newFiber.tag = OP.INSERT
       newFiber.node = null
       newFiber.insertPont = oldKids[oldHead]?.node
-      newFiber.parent = WIP
-      if (index === 0) {
-        WIP.child = newFiber
-      } else {
-        prev.sibling = newFiber
-      }
-      prev = newFiber
-      index++
     }
   } else if (newHead > newTail) {
     for (let i = oldHead; i <= oldTail; i++) {
@@ -181,10 +162,20 @@ const reconcileChildren = (WIP: any, children: FreNode): void => {
       commits.push(oldFiber)
     }
   }
+
+  for (var i = 0, prev = null; i < newKids.length; i++) {
+    const child = newKids[i]
+    child.parent = WIP
+    if (i > 0) {
+      prev.sibling = child
+    } else {
+      WIP.child = child
+    }
+    prev = child
+  }
 }
 
 const commitWork = (fiber: IFiber): void => {
-  console.log(commits)
   commits.forEach(commit)
   fiber.done?.()
   commits = []
@@ -209,7 +200,6 @@ const commit = (fiber: IFiber): void => {
   }
   if (tag & OP.INSERT) {
     const after = fiber.insertPoint as any
-    console.log(node, after)
     if (after === node) return
     if (after === null && node === parentNode.lastChild) return
     parentNode.insertBefore(node, after)

--- a/src/type.ts
+++ b/src/type.ts
@@ -34,9 +34,7 @@ export interface IHook {
   effect: IEffect[]
 }
 
-export type IRef = (
-  e: HTMLElement | undefined
-) => void | { current?: HTMLElement }
+export type IRef = (e: HTMLElement | undefined) => void | { current?: HTMLElement }
 
 export type FiberMap<P> = Record<string, IFiber<P>>
 
@@ -44,13 +42,11 @@ export interface IFiber<P extends Attributes = any> {
   key?: string
   lane?: any
   type: string | FC<P>
-  op: number
   parentNode: HTMLElementEx
   node: HTMLElementEx
   kids?: FiberMap<P>
   parent?: IFiber<P>
   sibling?: IFiber<P>
-  last?: IFiber<P>
   child?: IFiber<P>
   done?: () => void
   ref: IRef
@@ -58,22 +54,16 @@ export interface IFiber<P extends Attributes = any> {
   lastProps: P
   insertPoint: IFiber | null
   props: P
-  oldProps?: P
+  tag: number
 }
 
 export type HTMLElementEx = HTMLElement & { last: IFiber | null }
 export type IEffect = [Function?, number?, Function?]
 
 export type FreText = string | number
-export type FreNode =
-  | FreText
-  | FreElement
-  | FreNode[]
-  | boolean
-  | null
-  | undefined
+export type FreNode = FreText | FreElement | FreNode[] | boolean | null | undefined
 export type SetStateAction<S> = S | ((prevState: S) => S)
-export type Dispatch<A> = (value: A, resume?:boolean) => void
+export type Dispatch<A> = (value: A, resume?: boolean) => void
 export type Reducer<S, A> = (prevState: S, action: A) => S
 export type IVoidCb = () => void
 export type EffectCallback = () => void | (IVoidCb | undefined)
@@ -83,9 +73,7 @@ export interface PropsWithChildren {
   children?: FreNode
 }
 
-export type ITaskCallback =
-| ((time: boolean) => boolean)
-| null
+export type ITaskCallback = ((time: boolean) => boolean) | null
 
 export interface ITask {
   callback?: ITaskCallback


### PR DESCRIPTION
After thinking about this, I think the algorithm based on LIS or LCS is not suitable for fre, because the linked list must generate a new one every time. We can't use the O (nlogn) algorithm.

Previous refactoring failed, but this time I learned lessons.

This time, I use the O (n) algorithm based on both-end traversal, which can deal with common subprefixes and have more optimization space.

But undeniably, it is still difficult to implement this algorithm in the linked list data structure, but I will not give up.

Let me have a try!

- [x] mount and update
- [x] double buffering
- [ ] different type
- [ ] keyed
- [ ] simplify