### PR TITLE
Effect list

### DIFF
--- a/demo/src/keys.tsx
+++ b/demo/src/keys.tsx
@@ -39,7 +39,7 @@ import { h, render, useEffect, useState } from '../../src/index'
 function App() {
   const [key, setKey] = useState([1, 2, 3])
   return [
-    <button onClick={() => setKey([3, 4, 2, 5, 1])}>x</button>,
+    <button onClick={() => setKey([3, 2, 1])}>x</button>,
     <ul>
       {key.map((i) => (
         // <Li i={i} key={i} />

--- a/demo/src/keys.tsx
+++ b/demo/src/keys.tsx
@@ -45,7 +45,7 @@ function App() {
         // <Li i={i} key={i} />
         <li key={i}>{i}</li>
       ))}
-    </ul>,
+    </ul>
   ]
 }
 

--- a/src/type.ts
+++ b/src/type.ts
@@ -56,8 +56,6 @@ export interface IFiber<P extends Attributes = any> {
   tag: number
   time: number
   next: IFiber
-  first: IFiber,
-  last: IFiber
 }
 
 export type HTMLElementEx = HTMLElement & { last: IFiber | null }

--- a/src/type.ts
+++ b/src/type.ts
@@ -56,6 +56,7 @@ export interface IFiber<P extends Attributes = any> {
   tag: number
   time: number
   next: IFiber
+  a:any
 }
 
 export type HTMLElementEx = HTMLElement & { last: IFiber | null }

--- a/src/type.ts
+++ b/src/type.ts
@@ -56,6 +56,8 @@ export interface IFiber<P extends Attributes = any> {
   tag: number
   time: number
   next: IFiber
+  first: IFiber,
+  last: IFiber
 }
 
 export type HTMLElementEx = HTMLElement & { last: IFiber | null }

--- a/src/type.ts
+++ b/src/type.ts
@@ -56,7 +56,7 @@ export interface IFiber<P extends Attributes = any> {
   tag: number
   time: number
   next: IFiber
-  a:any
+  last: any
 }
 
 export type HTMLElementEx = HTMLElement & { last: IFiber | null }


### PR DESCRIPTION
根据 diff 顺序生成全局的 effectlist，这与 react 的收集方式本质完全不同

1. 只和 diff 顺序有关，先两端后中间，先移动后增删，先预处理后批处理
2. 不再需要 deletions 和 preCommit

这样做的好处对于 fre 来说有两点：

1. 更适合两端 diff，存在优化空间
2. 替代数组，不用担心爆栈

值得一提的是，react 已经完全删掉了 effectlist，我在第一个 commit 中简单实现了那个收集，很 tmd，该删

