### PR TITLE
New diff algorithm: Traverse from right to left

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -8,6 +8,6 @@
   </head>
   <body>
     <div id="app"></div>
-    <script type="module" src="/src/use-state.tsx"></script>
+    <script type="module" src="/src/keys.tsx"></script>
   </body>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -8,6 +8,6 @@
   </head>
   <body>
     <div id="app"></div>
-    <script type="module" src="/src/keys.tsx"></script>
+    <script type="module" src="/src/use-state.tsx"></script>
   </body>
 </html>

--- a/demo/src/keys.tsx
+++ b/demo/src/keys.tsx
@@ -76,22 +76,22 @@ import { render, useState } from "../../src/index"
 // }
 
 export default function App() {
-  const [state, setState] = useState( ["A", "B", "C", "D", "E"]);
+  const [state, setState] = useState( [1,2,3]);
 
   return (
-    <>
+    <div>
       {state.map((item) => {
-        return <div key={item}>{item}</div>;
+        return <li key={item}>{item}</li>;
       })}
 
       <button
         onClick={() => {
-          setState(["E", "C", "D"] );
+          setState([3,2,1] );
         }}
       >
         set
       </button>
-    </>
+    </div>
   );
 }
 

--- a/demo/src/keys.tsx
+++ b/demo/src/keys.tsx
@@ -76,17 +76,19 @@ import { render, useState } from "../../src/index"
 // }
 
 export default function App() {
-  const [state, setState] = useState( [1,2,3]);
+  const [state, setState] = useState([1, 2, 3]);
 
   return (
     <div>
-      {state.map((item) => {
-        return <li key={item}>{item}</li>;
-      })}
+      <ul>
+        {state.map((item) => {
+          return <li key={item}>{item}</li>;
+        })}
+      </ul>
 
       <button
         onClick={() => {
-          setState([1,3] );
+          setState([1, 3, 5]);
         }}
       >
         set

--- a/demo/src/keys.tsx
+++ b/demo/src/keys.tsx
@@ -86,7 +86,7 @@ export default function App() {
 
       <button
         onClick={() => {
-          setState([3,2,1] );
+          setState([1,3] );
         }}
       >
         set

--- a/demo/src/keys.tsx
+++ b/demo/src/keys.tsx
@@ -88,7 +88,7 @@ export default function App() {
 
       <button
         onClick={() => {
-          setState([1, 3, 5]);
+          setState([3,1,2,8,4]);
         }}
       >
         set

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "jest --coverage",
     "build": "rollup -c && gzip-size dist/fre.js",
     "dev": "rollup -c --watch",
-    "h": "jest ./test/h.test.tsx",
+    "key": "jest ./test/reconcilation.test.tsx",
     "prepublishOnly": "yarn build"
   },
   "description": "Tiny Concurrent UI library with Fiber.",

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -164,26 +164,22 @@ const reconcileChildren = (WIP: any, children: FreNode): void => {
         c = bCh[bHead]
         clone(c, oldKid)
         c.lane = LANE.INSERT
-        c.after = aCh[aHead]
         ch[bHead] = c
         aCh[map.get(key)] = null
       } else {
         c = bCh[bHead]
         c.lane = LANE.INSERT
         c.node = null
-        c.after = aCh[aHead]
       }
       bHead++
     }
   }
 
-  const after = ch[bTail + 1]
 
   while (bHead <= bTail) {
     let c = bCh[bHead]
     if (c) {
       c.lane = LANE.INSERT
-      c.after = after
       c.node = null
     }
     bHead++

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -193,7 +193,7 @@ const reconcileChildren = (WIP: any, children: FreNode): void => {
     }
     aHead++
   }
-  for (var i = 0, prev = null; i < bCh.length; i++) {
+  for (var i = bCh.length, prev = null; i >= 0; i--) {
     const child = bCh[i]
     child.parent = WIP
     if (i > 0) {
@@ -218,7 +218,7 @@ const getKey = (vdom) => (vdom == null ? vdom : vdom.key)
 const getType = (vdom) => (isFn(vdom.type) ? vdom.type.name : vdom.type)
 
 const commitWork = (fiber: IFiber): void => {
-  commit(fiber.parent? fiber : fiber.child)
+  commit(fiber.parent ? fiber : fiber.child)
   deletes.forEach(commit)
   fiber.done?.()
   deletes = []
@@ -309,7 +309,7 @@ const side = (effects: IEffect[]): void => {
   effects.length = 0
 }
 
-const next = (fiber)=>{
+const next = (fiber) => {
   fiber.lane = 0
   commit(fiber.child)
   commit(fiber.sibling)

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -149,7 +149,7 @@ const reconcileChildren = (WIP: any, children: FreNode): void => {
     while (aHead <= aTail) {
       let c = aCh[aTail--]
       c.lane = LANE.REMOVE
-      c.node.remove()
+      deletes.push(c)
     }
   } else {
     if (!keyed) {
@@ -169,8 +169,10 @@ const reconcileChildren = (WIP: any, children: FreNode): void => {
         c.lane = LANE.INSERT
       }
     }
-    for (var k in keyed) {
-      aCh[keyed[k]].node.remove()
+    for (const k in keyed) {
+      let c = aCh[keyed[k]]
+      c.lane = LANE.REMOVE
+      deletes.push(c)
     }
   }
 

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -265,9 +265,9 @@ function commit2(fiber) {
   let root = fiber
   let node = fiber
   while (true) {
-    commit(fiber)
     if (node.child) {
       node = node.child
+      commit(node, false)
       continue
     }
     if (node === root) return
@@ -276,34 +276,33 @@ function commit2(fiber) {
       node = node.parent
     }
     node = node.sibling
+    commit(node, true)
   }
 }
 
-const commit = (fiber: IFiber): void => {
-  if (!fiber) return
+const commit = (fiber: IFiber, bool): void => {
   let { type, lane, parentNode, node, ref } = fiber
   if (isFn(type)) {
     invokeHooks(fiber)
     wireKid(fiber)
-    return next(fiber)
-  }
-  if (lane & LANE.REMOVE) {
-    kidsRefer(fiber.kids)
-    parentNode.removeChild(fiber.node)
-    refer(ref, null)
-    fiber.lane = 0
     return
   }
+  // if (lane & LANE.REMOVE) {
+  //   kidsRefer(fiber.kids)
+  //   parentNode.removeChild(fiber.node)
+  //   refer(ref, null)
+  //   fiber.lane = 0
+  //   return
+  // }
   if (lane & LANE.UPDATE) {
     updateElement(node, fiber.lastProps || {}, fiber.props)
   }
   if (lane & LANE.INSERT) {
-
-    parentNode.insertBefore(fiber.node, fiber.sibling ? domPoint : null)
-    domPoint = fiber.node
+    parentNode.insertBefore(fiber.node, bool ? domPoint : null)
+    if (fiber.sibling) domPoint = fiber.node
+    
   }
   refer(ref, node)
-  next(fiber)
 }
 
 const same = (a, b) => {

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -193,14 +193,15 @@ const reconcileChildren = (WIP: any, children: FreNode): void => {
     }
     aHead++
   }
-  for (var i = bCh.length, prev = null; i >= 0; i--) {
+  for (var i = bCh.length - 1, prev = null; i >= 0; i--) {
     const child = bCh[i]
     child.parent = WIP
-    if (i > 0) {
-      prev.sibling = child
-    } else {
+    if (i === bCh.length-1) {
       if (WIP.lane & LANE.SVG) child.lane |= LANE.SVG
       WIP.child = child
+
+    } else {
+      prev.sibling = child
     }
     prev = child
   }


### PR DESCRIPTION
This is a large refactoring that uses some techniques to simplify the DOM pointer so that it can be removed from the reconcile phase.

For the fiber list, its traversal order is now completely reversed, from right to left instead of from left to right.

The DOM pointer is no longer used in the reconcile phase. In the commit phase, the DOM pointer changes in the order from right to left.

When this algorithm is landed, the effects (and refs) of subtree will be called in reverse order, but it is worth it.