### PR TITLE
startTransition API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,6 @@ export {
   useLayout,
   useLayout as useLayoutEffect,
 } from "./hook"
-export { shouldYield } from "./scheduler"
+export { shouldYield, startTransition } from "./scheduler"
 export { lazy, Suspense, ErrorBoundary } from "./boundary"
 export * from "./type"

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -9,7 +9,7 @@ import {
 } from "./type"
 import { createElement } from "./dom"
 import { resetCursor } from "./hook"
-import { scheduleWork, shouldYield, schedule } from "./scheduler"
+import { scheduleWork, shouldYield, startTransition } from "./scheduler"
 import { isArr, createText } from "./h"
 import { commitWork } from './commit'
 
@@ -234,7 +234,7 @@ function invokeHooks(fiber) {
       hooks.list.forEach((e) => e[2] && e[2]())
     } else {
       side(hooks.layout)
-      schedule(() => side(hooks.effect))
+      startTransition(() => side(hooks.effect))
     }
   }
 }

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -3,10 +3,10 @@ import { config } from './reconciler'
 
 const queue: ITask[] = []
 const threshold: number = 1000 / 60
-const unit = []
+const transitions = []
 let deadline: number = 0
 
-export const schedule = (cb) => unit.push(cb) === 1 && postMessage()
+export const startTransition = (cb) => transitions.push(cb) === 1 && postMessage()
 
 export const scheduleWork = (callback: ITaskCallback, fiber: IFiber): void => {
   const job = {
@@ -14,11 +14,11 @@ export const scheduleWork = (callback: ITaskCallback, fiber: IFiber): void => {
     fiber,
   }
   queue.push(job)
-  schedule(flushWork)
+  startTransition(flushWork)
 }
 
 const postMessage = (() => {
-  const cb = () => unit.splice(0, unit.length).forEach((c) => c())
+  const cb = () => transitions.splice(0, transitions.length).forEach((c) => c())
   if (typeof MessageChannel !== "undefined") {
     const { port1, port2 } = new MessageChannel()
     port1.onmessage = cb
@@ -41,7 +41,7 @@ const flushWork = (): void => {
     }
     job = peek(queue)
   }
-  job && schedule(flushWork)
+  job && startTransition(flushWork)
 }
 
 export const shouldYield = (): boolean => {


### PR DESCRIPTION
https://github.com/reactwg/react-18/discussions/41

This is an API for lowering priority, which is very useful, so I decide to build it in.

```js
function App() {
  const [count, setCount] = useState(0)

  console.log(count) // 1 2

  const update = () =>{
    startTransition(()=>{
      setCount(2)
    })
    setCount(c => 1)
  }
  return <>
      <h1>{count}</h1>
      <button onClick={}>+</button>
    </>
}
```
It works can be understood as `setTimeout (cb, 0)`, but the callback function is executed synchronously, and the update is delayed asynchronously.