### PR TITLE
double-timeout-queue

### DIFF
--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -50,13 +50,12 @@ export const scheduleWork = (callback: ITaskCallback, fiber: IFiber): void => {
 }
 
 const postMessage = (() => {
-  const cb = () => transit
   if (typeof MessageChannel !== "undefined") {
     const { port1, port2 } = new MessageChannel()
-    port1.onmessage = cb
+    port1.onmessage = transit
     return () => port2.postMessage(null)
   }
-  return () => setTimeout(cb)
+  return () => setTimeout(transit)
 })()
 
 const flushWork = (): void => {

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -3,9 +3,8 @@ import { config } from './reconciler'
 
 const queue: ITask[] = []
 const threshold: number = 1000 / 60
-const transitions = []
 let deadline: number = 0
-
+// for transtion queue
 let frame = 0
 let lightQueue = []
 let deferQueue = []
@@ -21,6 +20,7 @@ const consume = function (queue, timeout) {
     queue.splice(0, i)
   }
 }
+
 const transit = function () {
   frame++
   const timeout = performance.now() + (1 << 4) * ~~(frame >> 3)
@@ -31,7 +31,7 @@ const transit = function () {
     lightQueue.length = 0
   }
   if (lightQueue.length + deferQueue.length > 0) {
-    startTransition(transit)
+    postMessage()
   } else {
     frame = 0
   }

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -21,7 +21,7 @@ const consume = function (queue, timeout) {
     queue.splice(0, i)
   }
 }
-const flush = function () {
+const transit = function () {
   frame++
   const timeout = performance.now() + (1 << 4) * ~~(frame >> 3)
   consume(lightQueue, timeout)
@@ -31,14 +31,14 @@ const flush = function () {
     lightQueue.length = 0
   }
   if (lightQueue.length + deferQueue.length > 0) {
-    startTransition(flush)
+    startTransition(transit)
   } else {
     frame = 0
   }
 }
 
 
-export const startTransition = (cb) => transitions.push(cb) === 1 && postMessage()
+export const startTransition = (cb) => lightQueue.push(cb) === 1 && postMessage()
 
 export const scheduleWork = (callback: ITaskCallback, fiber: IFiber): void => {
   const job = {
@@ -50,7 +50,7 @@ export const scheduleWork = (callback: ITaskCallback, fiber: IFiber): void => {
 }
 
 const postMessage = (() => {
-  const cb = () => transitions.splice(0, transitions.length).forEach((c) => c())
+  const cb = () => transit
   if (typeof MessageChannel !== "undefined") {
     const { port1, port2 } = new MessageChannel()
     port1.onmessage = cb


### PR DESCRIPTION
### based on https://github.com/yisar/fre/pull/277

Since fre has no event level scheduling, I use a new technique to reduce the priority of startTransition.

It is called `double-timeout-queue`, the basic principle is to use two queues, and then I used the heuristic timeout algorithm of [queuing theory](https://en.wikipedia.org/wiki/Queueing_theory).


For components update, we still use `time slicing`, which is no problem, but startTransition is for functions, which may does not cause components update. Priority scheduling is invalid for ordinary functions.

The timeout queue is still valid. I think fre is better than react.

