### PR TITLE
fix: hook dep change compare replace '===' to 'Object.is'

### DIFF
--- a/demo/src/use-effect.tsx
+++ b/demo/src/use-effect.tsx
@@ -7,12 +7,13 @@ import {render, useState, useEffect ,h} from '../../src'
 function Counter({ id, remove }) {
   const [count, setCount] = useState(0)
 
-  // useEffect(() => {
-  //   console.log(`111`)
-  //   return () => {
-  //     console.log(`222`)
-  //   }
-  // })
+  useEffect(() => {
+      console.log(count);
+      // console.log(`111`)
+    // return () => {
+    //   console.log(`222`)
+    // }
+  }, [NaN])
 
   return (
     <div>

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -96,5 +96,5 @@ export const getHook = <S = Function | undefined, Dependency = any>(
 }
 
 export const isChanged = (a: DependencyList, b: DependencyList) => {
-  return !a || a.length !== b.length || b.some((arg, index) => arg !== a[index])
+  return !a || a.length !== b.length || b.some((arg, index) => !Object.is(arg, a[index]))
 }


### PR DESCRIPTION
reason: https://dev.to/kennethlum/why-reactjs-using-object-is-comparison-is-better-than-using-1kf3