### PR TITLE
improve h performance

### DIFF
--- a/src/h.ts
+++ b/src/h.ts
@@ -4,24 +4,33 @@ import { FreElement } from "./type"
 // for jsx2
 export const h = (type, props: any, ...kids) => {
   props = props || {}
-  const c = arrayfy(props.children || kids)
-  kids = flat(c).filter(some)
+  kids = flat(arrayfy(props.children || kids))
+
   if (kids.length) props.children = kids.length === 1 ? kids[0] : kids
-  let key = props.key || null,
-    ref = props.ref || null
-  delete props.key
-  delete props.ref
+
+  const key = props.key || null
+  const ref = props.ref || null
+
+  if (key) props.key = undefined
+  if (ref) props.ref = undefined
+
   return createVnode(type, props, key, ref)
 }
 
 const some = (x: unknown) => x != null && x!== true && x !== false
 
-const flat = (arr) =>
-  [].concat(
-    ...arr.map((v) =>
-      isArr(v) ? [].concat(flat(v)) : isStr(v) ? createText(v) : v
-    )
-  )
+const flat = (arr: any[], target = []) => {
+  arr.forEach((v) => {
+    if (isArr(v)) {
+      flat(v, target)
+    } else {
+      if (some(v)) {
+        target.push(isStr(v) ? createText(v) : v)
+      }
+    }
+  })
+  return target;
+}
 
 export const createVnode = (type, props, key, ref) => ({
   type,


### PR DESCRIPTION
Hello again!

I've noticed some performance issues in the main `h` function.
These are:
1) using `delete` on props - this modifies props shape and hidden classes, so it's much more efficient just to set the `ref` and `key` to undefined when they exist in props
2) `flat` function is using `concat` and spreads, which both are quite slow operations. I've rewritten it using plain `forEach` iteration and also fused it with your `some` filter function, so there is no temporary array. 
It's about 2x faster than your version: https://jsben.ch/VKq8X

So, all of this give 2.5-3x performance speedup on some common JSX, here's the benchmark: https://jsben.ch/vLEYO

Will be glad be hear any feedback!